### PR TITLE
Updating edge_proxy.js

### DIFF
--- a/apigee-cf-service-broker/helpers/edge_proxy.js
+++ b/apigee-cf-service-broker/helpers/edge_proxy.js
@@ -54,7 +54,7 @@ function createProxy (bindReq, callback) {
       callback(loggerError)
     } else {
       var proxyUrlRoot = template(proxyHostTemplate, union)
-      bindReq.proxyURL = 'https://' + proxyUrlRoot + '/' + bindReq.binding_id
+      bindReq.proxyURL = 'https://' + proxyUrlRoot + '/' + bindReq.binding_id + '/'
       bindReq.proxyname = proxyName
       logger.log.info('route proxy url:', bindReq.proxyURL, '->', bindReq.proxyname)
       callback(null, bindReq)  // bindReq request plus added results becomes bindRes response


### PR DESCRIPTION
This commit is to ensure that if any PCF applications expect to run at "app-route.pcf.apigee.com/guid/" versus "app-route.pcf.apigee.com/guid", it's able to.